### PR TITLE
fix: correct RenovateBot Package Manager for go.mod files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
       "enabled": true,
       "matchManagers": [
         "bazel",
-        "go"
+        "gomod"
       ]
     },
     {


### PR DESCRIPTION
Lacking a checker for renovateBot files, typo occurred:

> Location: .github/renovate.json
> Error type: The renovate configuration file contains some invalid settings
> Message: packageRules:
> You have included an unsupported manager in a package rule. Your list: bazel,go.
> Supported managers are: (... bazel, bazel-module, bazelisk, ... cargo, ... gomod, ...)