### PR TITLE
fix: enable RenovateBot to automerge more

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,13 +10,17 @@
     {
       "enabled": true,
       "matchManagers": [
-        "bazel",
+        "bazel-module",
+        "github-actions",
         "gomod"
       ]
     },
     {
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
+      "automerge": true,
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Seeing that Bazel-modules and GitHub-actions are not auto merged, let's enable that too.  Allows me to be lazier.