### PR TITLE
fix: delay updates a few days to reduce risk

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,5 +22,6 @@
         "minor"
       ]
     }
-  ]
+  ],
+  "stabilityDays": 3
 }


### PR DESCRIPTION
I'm seeing a few of the updates fetched by RenovateBot are really very fresh.

I'd rather others detect bad updates -- I'm selfish that way -- so let the updates cook upstream a few days, see if there are any bugs that lead to updates being yoinked before we try to apply.