### PR TITLE
chore: use setup-bazel to maintain less setup code

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -26,38 +26,21 @@ jobs:
         id: week
         run: echo "::set-output name=iso::$(date +'bazel-%YW%U')"
       -
-        name: Expand Paths
-        # paste that info into keys that self-document a bit better
-        id: env
-        env:
-          CACHE_BASE: "/tmp/cache"
-        run: |
-          echo "::set-output name=cache-base::${{ env.CACHE_BASE }}"
-          echo "::set-output name=cache-key::${{ steps.week.outputs.iso }}"
-          echo "::set-output name=cache-path::${{ env.CACHE_BASE }}/${{ steps.week.outputs.iso }}"
-      -
-        name: Mount bazel cache  # Optional
-        # The effect of this allows the bazel actions to build / test with an output_dir equal to
-        # the key subdir in the path, so the week-based cache path gets cached
-        uses: actions/cache@v4
+        uses: bazel-contrib/setup-bazel@0.8.5
         with:
-          # Mount the cache at the expanded PATH
-          path: ${{ steps.env.outputs.cache-base }}
-          # key expires each week, allowing old cache info to age out
-          key: ${{ steps.env.outputs.cache-key }}
+          # Cache bazel downloads via bazelisk
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ steps.week.outputs.iso }}
+          # Share repository cache between workflows.
+          repository-cache: true
       -
         uses: actions/checkout@v4
         # action runners have bazelisk: - uses: bazelbuild/setup-bazelisk@v2
         # https://github.com/bazelbuild/bazel/issues/11062
       -
-        env:
-          # typically used for bazel internal testing: changes outputRoot, sets idletimeout to ~15s
-          TEST_TMPDIR: ${{ steps.env.outputs.cache-path }}
         run: bazel build //...
       -
-        env:
-          # typically used for bazel internal testing: changes outputRoot, sets idletimeout to ~15s
-          TEST_TMPDIR: ${{ steps.env.outputs.cache-path }}
         run: bazel test //... --test_output=errors --test_summary=detailed
       -
         run: bazel shutdown


### PR DESCRIPTION
Use https://github.com/bazel-contrib/setup-bazel rather than my own setup scripts.  The only thing missed is perhaps TEST_TMPDIR used to limit the timeout/suicide of the backend engine/daemon