### PR TITLE
fix: allow regex updates to go version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
       "matchManagers": [
         "bazel-module",
         "github-actions",
-        "gomod"
+        "gomod",
+        "regex"
       ]
     },
     {
@@ -21,6 +22,15 @@
         "patch",
         "minor"
       ]
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["MODULE.bazel$"],
+      "matchStrings": [
+        "\"renovate_datasource\": \"(?<datasource>.*?)\",\\s    \"renovate_depname\": \"(?<depName>.*?)\",\\s(    \"renovate_versioning\": \"(?<versioning>.*?)\",\\s)?(    \"sha256\": \"(?<currentDigest>.*?)\",\\s)?    \"version\": \"(?<currentValue>.*?)\"",
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
     }
   ],
   "stabilityDays": 3

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,8 +3,15 @@ bazel_dep(name = "gazelle", version = "0.38.0")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
+# This structure updated by RenovateBot, regex manager
+go_version = {
+    "renovate_datasource": "github-tags",
+    "renovate_depname": "golang/go",
+    "version": "go1.22.4"
+}
+
 # Download an SDK for the host OS & architecture as well as common remote execution platforms.
-go_sdk.download(version = "1.22.4")
+go_sdk.download(version = go_version["version"].lstrip("go"))
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")


### PR DESCRIPTION
By allowing RenovateBot's regex manager to update the go version, we can stay fairly leading-edge, merging only when builds succeed.

We can later replicate towards a recurring build workflow that does a `go mod tidy` without relying on Bazel so that the chicken-and-egg of a butchered go.mod blocking a bazel run to fix it doesn't recur.